### PR TITLE
chore: bump node and bson

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,5 @@ on:
 
 jobs:
   test:
-    uses: hapijs/.github/.github/workflows/ci-module.yml@master
-    with:
-      min-node-version: 14
+    uses: hapijs/.github/.github/workflows/ci-module.yml@min-node-18-hapi-21
+

--- a/package.json
+++ b/package.json
@@ -6,13 +6,16 @@
     "type": "git",
     "url": "git://github.com/Marsup/joi-objectid.git"
   },
+  "engines": {
+    "node": ">= 18"
+  },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "test": "lab -M 5000 -t 100 -a @hapi/code -L"
   },
   "dependencies": {
-    "bson": "^4.7.2"
+    "bson": "^6.3.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.3",
@@ -20,7 +23,7 @@
     "joi": "^17.12.1"
   },
   "peerDependencies": {
-    "joi": "^17.12.1"
+    "joi": ">= 17.12.1"
   },
   "keywords": ["joi", "extension", "objectid"],
   "author": "Nicolas Morel",


### PR DESCRIPTION
Upgrade to latest bson module and recommend a non-deprecated node version